### PR TITLE
Update tolerations in pod example

### DIFF
--- a/hello-pod.yaml
+++ b/hello-pod.yaml
@@ -23,6 +23,7 @@ spec:
             'operator': 'In'
             'values': ["true"]
   tolerations:
-    - effect: NoSchedule
-      key: nautilus.io/csu-tide
-      operator: Exists
+    - key: nautilus.io/reservation
+      operator: Equal
+      value: csu-tide
+      effect: NoSchedule


### PR DESCRIPTION
## Summary
- update Kubernetes toleration example to use the `nautilus.io/reservation` key

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_687922fa2b108329b33043afc6f29416